### PR TITLE
fix: respect IndexFile and LinkToIndexes configuration for "Go Up" link

### DIFF
--- a/internal/webindexer/templates/themes/default.html.tmpl
+++ b/internal/webindexer/templates/themes/default.html.tmpl
@@ -63,9 +63,9 @@
             <th>Size</th>
             <th>Last Modified</th>
         </tr>
-        {{ if .HasParent }}
+        {{ if .ParentURL }}
         <tr>
-            <td class="filename"><a href="../index.html">
+            <td class="filename"><a href="{{ .ParentURL }}">
                 <span class="icon">🔼</span>Go Up</a>
             </td>
             <td>-</td>

--- a/internal/webindexer/templates/themes/dracula.html.tmpl
+++ b/internal/webindexer/templates/themes/dracula.html.tmpl
@@ -122,9 +122,9 @@
             <th>Size</th>
             <th>Last Modified</th>
         </tr>
-        {{ if .HasParent }}
+        {{ if .ParentURL }}
         <tr>
-            <td class="filename"><a href="../index.html">
+            <td class="filename"><a href="{{ .ParentURL }}">
                 <span class="icon">🔼</span>Go Up</a>
             </td>
             <td>-</td>

--- a/internal/webindexer/templates/themes/nord.html.tmpl
+++ b/internal/webindexer/templates/themes/nord.html.tmpl
@@ -133,9 +133,9 @@
             <th>Size</th>
             <th>Last Modified</th>
         </tr>
-        {{ if .HasParent }}
+        {{ if .ParentURL }}
         <tr>
-            <td class="filename"><a href="../index.html">
+            <td class="filename"><a href="{{ .ParentURL }}">
                 <span class="icon">🔼</span>Go Up</a>
             </td>
             <td>-</td>

--- a/internal/webindexer/templates/themes/solarized.html.tmpl
+++ b/internal/webindexer/templates/themes/solarized.html.tmpl
@@ -126,9 +126,9 @@
             <th>Size</th>
             <th>Last Modified</th>
         </tr>
-        {{ if .HasParent }}
+        {{ if .ParentURL }}
         <tr>
-            <td class="filename"><a href="../index.html">
+            <td class="filename"><a href="{{ .ParentURL }}">
                 <span class="icon">🔼</span>Go Up</a>
             </td>
             <td>-</td>

--- a/internal/webindexer/webindexer.go
+++ b/internal/webindexer/webindexer.go
@@ -66,6 +66,7 @@ type Data struct {
 	Items        []Item
 	Parent       string
 	HasParent    bool
+	ParentURL    string
 }
 
 type BackendSetup interface {
@@ -321,6 +322,9 @@ func (i Indexer) data(items []Item, path string) (Data, error) {
 		}
 		data.Parent = resolveParentPath(i.Cfg.BaseURL, relativeParent, i.Cfg.IndexFile, i.Cfg.LinkToIndexes)
 		data.HasParent = parent != path
+		if data.HasParent {
+			data.ParentURL = resolveItemURL(i.Cfg.BaseURL, relativeParent, "..", true, i.Cfg.LinkToIndexes, i.Cfg.IndexFile)
+		}
 	}
 
 	// Process items within the data function to set their URLs


### PR DESCRIPTION
fixes #85 

Although the existing template data `Parent` and `HasParent` is technically not necessary anymore, I left them there for backward compatibility purposes, in case somebody is relying on them in a custom template.