### PR TITLE
feat: allow specifying custom S3 endpoint

### DIFF
--- a/internal/webindexer/config.go
+++ b/internal/webindexer/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	Title          string   `yaml:"title"         mapstructure:"title"`
 	CfgFile        string   `yaml:"-"`
 	BasePath       string   `yaml:"-"`
+	S3Endpoint     string   `yaml:"s3_endpoint"   mapstructure:"s3_endpoint"`
 }
 
 type SortBy string

--- a/internal/webindexer/webindexer.go
+++ b/internal/webindexer/webindexer.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/charmbracelet/log"
@@ -147,7 +148,11 @@ func setupBackends(indexer *Indexer) error {
 
 	if isS3URI(indexer.Cfg.Source) || isS3URI(indexer.Cfg.Target) {
 		log.Debug("Setting up S3 session")
-		sess, err := session.NewSession()
+		cfg := aws.NewConfig()
+		if indexer.Cfg.S3Endpoint != "" {
+			cfg = cfg.WithEndpoint(indexer.Cfg.S3Endpoint)
+		}
+		sess, err := session.NewSession(cfg)
 		if err != nil {
 			return fmt.Errorf("failed to create AWS session: %w", err)
 		}

--- a/main.go
+++ b/main.go
@@ -124,6 +124,7 @@ func init() {
 	cobra.OnInitialize(initConfig(&cfg.CfgFile))
 
 	rootCmd.PersistentFlags().StringVarP(&cfg.CfgFile, "config", "c", "", "config file")
+	rootCmd.Flags().StringVarP(&cfg.S3Endpoint, "s3-endpoint", "", "", "The S3 endpoint to use. Only needed for non-AWS S3 endpoints.")
 	rootCmd.Flags().StringVarP(&cfg.BaseURL, "base-url", "u", "", "A URL to prepend to the links")
 	rootCmd.Flags().StringVarP(&cfg.DateFormat, "date-format", "", "2006-01-02 15:04:05 MST", "The date format to use in the index page")
 	rootCmd.Flags().BoolVarP(&cfg.DirsFirst, "dirs-first", "", true, "List directories first")


### PR DESCRIPTION
The AWS SDK supports overriding some options, like region, via environment variables, and its config file, but I found no way of overriding the endpoint URL. The PR adds an `--s3-endpoint` option that makes it possible to use non-AWS S3 storage services. I've specifically tested this with Minio.