### PR TITLE
feat: align S3 and Docker timezone handling with local filesystem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine
-RUN apk add --no-cache bash ca-certificates
+RUN apk add --no-cache bash ca-certificates tzdata
 COPY web-indexer /usr/bin/web-indexer
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /usr/bin/web-indexer /entrypoint.sh

--- a/internal/webindexer/s3.go
+++ b/internal/webindexer/s3.go
@@ -79,7 +79,7 @@ func (s *S3Backend) Read(prefix string) ([]Item, bool, error) {
 		item := Item{
 			Name:         itemName,
 			Size:         humanizeBytes(*content.Size),
-			LastModified: content.LastModified.Format(s.cfg.DateFormat),
+			LastModified: content.LastModified.Local().Format(s.cfg.DateFormat),
 			IsDir:        false,
 		}
 


### PR DESCRIPTION
Generating from S3 yields indexes with different timestamps (timezones) compared to running it on the same set of files locally. Goal of this PR is to make them work the same way, by converting S3 timestamps to local timezone. Adding `tzdata` is beneficial for the docker image, as that way the timezone set via `TZ` is honored (it adds ~436 KiB to the uncompressed image size though).