### PR TITLE
Honor sort_by field when order is desc

### DIFF
--- a/internal/webindexer/sort.go
+++ b/internal/webindexer/sort.go
@@ -1,6 +1,7 @@
 package webindexer
 
 import (
+	"slices"
 	"sort"
 	"strconv"
 	"unicode"
@@ -17,9 +18,7 @@ func (i *Indexer) sort(items *[]TemplateItem) {
 	}
 
 	if i.Cfg.OrderByValue() == OrderDesc {
-		sort.SliceStable(*items, func(i, j int) bool {
-			return !cmpNatural((*items)[i].Name, (*items)[j].Name)
-		})
+		slices.Reverse(*items)
 	}
 
 	if i.Cfg.DirsFirst {
@@ -35,7 +34,7 @@ func orderByName(items *[]TemplateItem) {
 
 func orderByLastModified(items *[]TemplateItem) {
 	sort.SliceStable(*items, func(i, j int) bool {
-		return (*items)[i].LastModified > (*items)[j].LastModified
+		return (*items)[i].LastModified < (*items)[j].LastModified
 	})
 }
 

--- a/internal/webindexer/sort_test.go
+++ b/internal/webindexer/sort_test.go
@@ -26,7 +26,7 @@ func TestOrderByLastModified(t *testing.T) {
 		{Name: "apple", LastModified: "2020-01-01"},
 		{Name: "cherry", LastModified: "2020-01-02"},
 	}
-	expectedOrder := []string{"banana", "cherry", "apple"} // descending order
+	expectedOrder := []string{"apple", "cherry", "banana"} // ascending order
 	orderByLastModified(&items)
 
 	for i, item := range items {
@@ -66,4 +66,91 @@ func TestOrderDirsFirst(t *testing.T) {
 			t.Errorf("expected %t, got %t for %s", expectedOrderIsDir[i], item.IsDir, item.Name)
 		}
 	}
+}
+
+func assertOrder(t *testing.T, items []TemplateItem, expected []string) {
+	t.Helper()
+	for i, item := range items {
+		if item.Name != expected[i] {
+			t.Errorf("expected %v, got %s at index %d", expected, item.Name, i)
+			return
+		}
+	}
+}
+
+func TestSort_NameDesc(t *testing.T) {
+	items := []TemplateItem{
+		{Name: "banana"},
+		{Name: "apple"},
+		{Name: "cherry"},
+	}
+	idx := &Indexer{Cfg: Config{SortBy: "name", Order: "desc"}}
+	idx.sort(&items)
+	assertOrder(t, items, []string{"cherry", "banana", "apple"})
+}
+
+func TestSort_NaturalNameDesc(t *testing.T) {
+	items := []TemplateItem{
+		{Name: "item10"},
+		{Name: "item2"},
+		{Name: "item1"},
+	}
+	idx := &Indexer{Cfg: Config{SortBy: "natural_name", Order: "desc"}}
+	idx.sort(&items)
+	assertOrder(t, items, []string{"item10", "item2", "item1"})
+}
+
+func TestSort_LastModifiedDesc(t *testing.T) {
+	items := []TemplateItem{
+		{Name: "banana", LastModified: "2020-01-03"},
+		{Name: "apple", LastModified: "2020-01-01"},
+		{Name: "cherry", LastModified: "2020-01-02"},
+	}
+	idx := &Indexer{Cfg: Config{SortBy: "last_modified", Order: "desc"}}
+	idx.sort(&items)
+	assertOrder(t, items, []string{"banana", "cherry", "apple"})
+}
+
+func TestSort_LastModifiedAsc(t *testing.T) {
+	items := []TemplateItem{
+		{Name: "banana", LastModified: "2020-01-03"},
+		{Name: "apple", LastModified: "2020-01-01"},
+		{Name: "cherry", LastModified: "2020-01-02"},
+	}
+	idx := &Indexer{Cfg: Config{SortBy: "last_modified", Order: "asc"}}
+	idx.sort(&items)
+	assertOrder(t, items, []string{"apple", "cherry", "banana"})
+}
+
+func TestSort_DirsFirstWithLastModifiedDesc(t *testing.T) {
+	items := []TemplateItem{
+		{Name: "file-b.txt", LastModified: "2020-01-03", IsDir: false},
+		{Name: "dir-a", LastModified: "2020-01-01", IsDir: true},
+		{Name: "file-a.txt", LastModified: "2020-01-02", IsDir: false},
+		{Name: "dir-b", LastModified: "2020-01-04", IsDir: true},
+	}
+	idx := &Indexer{Cfg: Config{SortBy: "last_modified", Order: "desc", DirsFirst: true}}
+	idx.sort(&items)
+
+	// Dirs must come first, each group ordered newest-first.
+	assertOrder(t, items, []string{"dir-b", "dir-a", "file-b.txt", "file-a.txt"})
+	expectedIsDir := []bool{true, true, false, false}
+	for i, item := range items {
+		if item.IsDir != expectedIsDir[i] {
+			t.Errorf("expected IsDir=%t, got %t for %s", expectedIsDir[i], item.IsDir, item.Name)
+		}
+	}
+}
+
+func TestSort_DirsFirstWithNameAsc(t *testing.T) {
+	items := []TemplateItem{
+		{Name: "zeta.txt", IsDir: false},
+		{Name: "alpha-dir", IsDir: true},
+		{Name: "beta.txt", IsDir: false},
+		{Name: "omega-dir", IsDir: true},
+	}
+	idx := &Indexer{Cfg: Config{SortBy: "name", Order: "asc", DirsFirst: true}}
+	idx.sort(&items)
+
+	assertOrder(t, items, []string{"alpha-dir", "omega-dir", "beta.txt", "zeta.txt"})
 }


### PR DESCRIPTION
Fixes `sort_by` being ignored if `order` is `desc`. Previously, descending order silently used `natural_name` for everything.

Note: `sort_by: date` with the default `order: asc` used to actually return items in descending order, this PR also corrects that to return them in ascending order, so this is also a breaking change.